### PR TITLE
fix #35 : TestService PersistenceContext 의존성 제거

### DIFF
--- a/src/main/java/practice/fundingboost2/item/funding/app/ContributorService.java
+++ b/src/main/java/practice/fundingboost2/item/funding/app/ContributorService.java
@@ -13,7 +13,7 @@ public class ContributorService {
     private final ContributorRepository contributorRepository;
 
     @Transactional
-    public void save(Contributor contributor) {
-        contributorRepository.save(contributor);
+    public Contributor save(Contributor contributor) {
+        return contributorRepository.save(contributor);
     }
 }

--- a/src/main/java/practice/fundingboost2/item/gifthub/app/GifthubService.java
+++ b/src/main/java/practice/fundingboost2/item/gifthub/app/GifthubService.java
@@ -19,7 +19,7 @@ public class GifthubService {
     private final GifthubRepository gifthubRepository;
     private final ItemService itemService;
 
-    public Gifthub findCart(GifthubId gifthubId) {
+    public Gifthub findGifthub(GifthubId gifthubId) {
         return gifthubRepository.findById(gifthubId)
             .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_GIFTHUB_ITEM));
     }
@@ -46,14 +46,14 @@ public class GifthubService {
     }
 
     public CommonSuccessDto deleteFromCart(Long memberId, Long itemId, Long optionId) {
-        Gifthub cart = findCart(new GifthubId(memberId, itemId, optionId));
+        Gifthub cart = findGifthub(new GifthubId(memberId, itemId, optionId));
         gifthubRepository.delete(cart);
 
         return CommonSuccessDto.fromEntity(true);
     }
 
     public CommonSuccessDto updateCart(Long memberId, Long itemId, Long optionId, Integer quantity) {
-        Gifthub cart = findCart(new GifthubId(memberId, itemId, optionId));
+        Gifthub cart = findGifthub(new GifthubId(memberId, itemId, optionId));
 
         cart.updateQuantity(quantity);
 

--- a/src/main/java/practice/fundingboost2/member/app/MemberService.java
+++ b/src/main/java/practice/fundingboost2/member/app/MemberService.java
@@ -23,7 +23,6 @@ public class MemberService {
             .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_LOGIN_USER));
     }
 
-    @Transactional
     public Boolean existsById(Long id) {
         return memberRepository.existsById(id);
     }

--- a/src/main/java/practice/fundingboost2/member/repo/entity/Member.java
+++ b/src/main/java/practice/fundingboost2/member/repo/entity/Member.java
@@ -85,7 +85,7 @@ public class Member {
     }
 
     public void validateNickname(String nickname) {
-        if (this.email.equals(nickname)) {
+        if (this.nickname.equals(nickname)) {
             throw new CommonException(ErrorCode.ALREADY_EXISTS_EMAIL);
         }
     }

--- a/src/test/java/practice/fundingboost2/auth/app/AuthValidatorTest.java
+++ b/src/test/java/practice/fundingboost2/auth/app/AuthValidatorTest.java
@@ -1,0 +1,60 @@
+package practice.fundingboost2.auth.app;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import practice.fundingboost2.common.exception.CommonException;
+import practice.fundingboost2.member.repo.entity.Member;
+
+@SpringBootTest
+class AuthValidatorTest {
+
+    List<Member> members = new ArrayList<>();
+
+    final int MEMBER_SIZE = 5;
+
+    @Autowired
+    AuthValidator authValidator;
+
+    @BeforeEach
+    void init() {
+        IntStream.range(0, MEMBER_SIZE)
+            .forEach(
+                i -> members.add(new Member("email" + i, "nickname" + i, "imageUrl" + i, "phoneNumber" + i))
+            );
+    }
+    
+    @Test
+    void givenMembers_whenEmailAndNicknameDoesNotExists_thenMustNotThrowException() {
+        // given
+        // when
+        // then
+        assertThatNoException()
+            .isThrownBy(() -> authValidator.validateEmailAndNickname(members, "newEmail", "newNickname"));
+    }
+
+    @Test
+    void givenMembers_whenEmailDuplicated_thenThrowException() {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> authValidator.validateEmailAndNickname(members, members.getFirst().getEmail(), "newNickname"))
+            .isInstanceOf(CommonException.class);
+    }
+
+    @Test
+    void givenMembers_whenNicknameDuplicated_thenThrowException() {
+        // given
+        // when
+        // then
+        assertThatThrownBy(() -> authValidator.validateEmailAndNickname(members, "newEmail", members.getFirst().getNickname()))
+            .isInstanceOf(CommonException.class);
+    }
+}

--- a/src/test/java/practice/fundingboost2/item/funding/app/ContributorServiceTest.java
+++ b/src/test/java/practice/fundingboost2/item/funding/app/ContributorServiceTest.java
@@ -1,0 +1,54 @@
+package practice.fundingboost2.item.funding.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import practice.fundingboost2.item.funding.app.interfaces.FundingRepository;
+import practice.fundingboost2.item.funding.repo.entity.Contributor;
+import practice.fundingboost2.item.funding.repo.entity.Funding;
+import practice.fundingboost2.item.funding.repo.jpa.ContributorRepository;
+import practice.fundingboost2.member.repo.MemberRepository;
+import practice.fundingboost2.member.repo.entity.Member;
+
+@SpringBootTest
+class ContributorServiceTest {
+
+    @Autowired
+    ContributorService contributorService;
+
+    @Autowired
+    ContributorRepository contributorRepository;
+
+    @Autowired
+    FundingRepository fundingRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    void givenContributor_whenSave_thenCanFindContributor() {
+        // given
+        Member member = new Member("email", "name", "image", "phone");
+        member.increasePoint(100_000);
+        Member friend = new Member("email", "name", "image", "phone");
+        friend.increasePoint(100_000);
+        Funding funding = new Funding(member, "message", "BIRTHDAY", LocalDateTime.now().plusDays(10));
+        funding.plusTotalPrice(10_000);
+        Contributor contributor = new Contributor(friend, funding, 1000);
+        memberRepository.save(member);
+        memberRepository.save(friend);
+        fundingRepository.save(funding);
+
+        // when
+        Contributor savedContributor = contributorService.save(contributor);
+
+        // then
+        Optional<Contributor> findContributor = contributorRepository.findById(savedContributor.getId());
+        assertThat(findContributor).isPresent();
+        assertThat(findContributor.get().getId()).isEqualTo(savedContributor.getId());
+    }
+}

--- a/src/test/java/practice/fundingboost2/item/item/app/ItemServiceTest.java
+++ b/src/test/java/practice/fundingboost2/item/item/app/ItemServiceTest.java
@@ -2,7 +2,6 @@ package practice.fundingboost2.item.item.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -63,7 +62,7 @@ class ItemServiceTest {
         item = itemRepository.findById(item.getId());
         assertThat(dto.isSuccess()).isTrue();
         assertThat(item.getLikeCount()).isEqualTo(1);
-        assertTrue(bookmarkRepository.existsById(bookmark.getId()));
+        assertThat(bookmarkRepository.existsById(bookmark.getId())).isTrue();
     }
 
     @Test
@@ -79,7 +78,7 @@ class ItemServiceTest {
 
         // then
         assertThat(item.getLikeCount()).isEqualTo(0);
-        assertFalse(bookmarkRepository.existsById(bookmark.getId()));
+        assertThat(bookmarkRepository.existsById(bookmark.getId())).isFalse();
     }
 
     @Test

--- a/src/test/java/practice/fundingboost2/member/app/MemberServiceTest.java
+++ b/src/test/java/practice/fundingboost2/member/app/MemberServiceTest.java
@@ -1,37 +1,33 @@
 package practice.fundingboost2.member.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 import practice.fundingboost2.common.exception.CommonException;
 import practice.fundingboost2.member.app.dto.GetMemberResponseDto;
 import practice.fundingboost2.member.app.dto.UpdateMemberRequestDto;
+import practice.fundingboost2.member.repo.MemberRepository;
 import practice.fundingboost2.member.repo.entity.Member;
 
 @SpringBootTest
-@Transactional
 class MemberServiceTest {
 
     @Autowired
     MemberService memberService;
 
-    @PersistenceContext
-    EntityManager em;
+    @Autowired
+    MemberRepository memberRepository;
 
     Member member;
 
     @BeforeEach
     void init() {
         member = new Member("email", "nickname", "imageUrl", "phoneNumber");
-        em.persist(member);
-        em.flush();
+        member = memberRepository.save(member);
     }
 
     @Test
@@ -53,7 +49,8 @@ class MemberServiceTest {
         Long NOT_EXISTS_ID = 100_000_000_000L;
         // when
         // then
-        assertThrows(CommonException.class, () -> memberService.getMember(NOT_EXISTS_ID));
+        assertThatThrownBy(() -> memberService.getMember(NOT_EXISTS_ID))
+            .isInstanceOf(CommonException.class);
     }
 
     @Test
@@ -74,5 +71,23 @@ class MemberServiceTest {
         GetMemberResponseDto updateDto = memberService.updateMember(member.getId(), dto);
         // then
         assertThat(updateDto.phoneNumber()).isEqualTo("newPhoneNumber");
+    }
+    
+    @Test
+    void givenMember_whenMemberExists_thenReturnTrue() {
+        // given
+        // when
+        Boolean result = memberService.existsById(member.getId());
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void whenMemberNotExists_thenReturnFalse() {
+        // given
+        // when
+        Boolean result = memberService.existsById(100_000_000_000L);
+        // then
+        assertThat(result).isFalse();
     }
 }

--- a/src/test/java/practice/fundingboost2/member/repo/MemberRepositoryTest.java
+++ b/src/test/java/practice/fundingboost2/member/repo/MemberRepositoryTest.java
@@ -1,0 +1,103 @@
+package practice.fundingboost2.member.repo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import practice.fundingboost2.member.repo.entity.Member;
+
+@DataJpaTest
+class MemberRepositoryTest {
+
+    Member member;
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    static final String NOT_EXISTS_EMAIL = "notExistsEmail";
+    static final String NOT_EXISTS_NICKNAME = "notExistsNickname";
+
+    @BeforeEach
+    void init() {
+        member = new Member("email", "nickname", "imageUrl", "phoneNumber");
+        em.persist(member);
+        em.flush();
+    }
+
+    @Test
+    void givenMember_whenFindByEmail_thenReturnFindMember() {
+        // given
+        // when
+        Optional<Member> findMember = memberRepository.findByEmail(member.getEmail());
+
+        // then
+        assertThat(findMember).isNotEmpty();
+        assertThat(findMember.get().getEmail()).isEqualTo(member.getEmail());
+        assertThat(findMember.get().getNickname()).isEqualTo(member.getNickname());
+        assertThat(findMember.get().getImageUrl()).isEqualTo(member.getImageUrl());
+        assertThat(findMember.get().getPhoneNumber()).isEqualTo(member.getPhoneNumber());
+    }
+    
+    @Test
+    void givenNotExistsEmailMember_whenFindByEmail_thenReturnEmptyOptional() {
+        // given
+        String NOT_EXISTS_EMAIL = "notExistsEmail";
+        // when
+        Optional<Member> findMember = memberRepository.findByEmail(NOT_EXISTS_EMAIL);
+        // then
+        assertThat(findMember).isEmpty();
+    }
+
+    @Test
+    void givenEmailAndNickname_whenFindByEmailOrNickname_thenReturnMemberList() {
+        // given
+        Member member2 = new Member("email", "nickname2", "imageUrl", "phoneNumber");
+        em.persist(member2);
+        em.flush();
+
+        // when
+        List<Member> members = memberRepository.findByEmailOrNickname(member.getEmail(),
+            member2.getNickname());
+
+        // then
+        assertThat(members).hasSize(2);
+    }
+
+    @Test
+    void givenNoMembers_whenFindByEmailOrNickname_thenReturnEmptyList() {
+        // given
+        // when
+        List<Member> members = memberRepository.findByEmailOrNickname(NOT_EXISTS_EMAIL, NOT_EXISTS_NICKNAME);
+        // then
+        assertThat(members).isEmpty();
+    }
+
+    @Test
+    void givenExistEmail_whenFindByEmailOrNickname_thenReturnFoundMember() {
+        // given
+        // when
+        List<Member> members = memberRepository.findByEmailOrNickname(member.getEmail(), NOT_EXISTS_NICKNAME);
+        // then
+        assertThat(members).hasSize(1);
+        assertThat(members.getFirst().getEmail()).isEqualTo(member.getEmail());
+    }
+
+    @Test
+    void givenExistNickname_whenFindByEmailOrNickname_thenReturnFoundMember() {
+        // given
+        // when
+        List<Member> members = memberRepository.findByEmailOrNickname(NOT_EXISTS_EMAIL, member.getNickname());
+        // then
+        assertThat(members).hasSize(1);
+        assertThat(members.getFirst().getNickname()).isEqualTo(member.getNickname());
+    }
+}

--- a/src/test/java/practice/fundingboost2/member/repo/entity/RelationTest.java
+++ b/src/test/java/practice/fundingboost2/member/repo/entity/RelationTest.java
@@ -1,0 +1,36 @@
+package practice.fundingboost2.member.repo.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import practice.fundingboost2.common.exception.CommonException;
+
+class RelationTest {
+
+    @Test
+    void givenMemberIdAndFriendId_thenCreateNewRelation() {
+        // given
+        Long memberId = 1L;
+        Long friendId = 2L;
+
+        // when
+        Relation relation = new Relation(memberId, friendId);
+        // then
+        assertThat(relation.getId()).isEqualTo(new RelationId(memberId, friendId));
+    }
+
+    @Test
+    void givenMemberIdAndFriendIdEquals_whenCreateRelation_thenThrowException() {
+        // given
+        Long memberId = 1L;
+        Long friendId = 1L;
+
+        // when
+        // then
+        assertThatThrownBy(() -> new Relation(memberId, friendId))
+            .isInstanceOf(CommonException.class);
+    }
+
+
+}


### PR DESCRIPTION
🚀 개요
close #35 

repository 의존성을 없애기 위해 PersistenceContext를 제거하고 @Transactional 애노테이션을 테스트에서 제외했습니다.

🔍 변경사항
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

📝 논의사항